### PR TITLE
Create libyab.so, as well as an install target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ yab-IDE is a powerful development environment, which of course is programmed in 
 
 Compiling
 ---------------------
-run `make` in `src`.
-
-run `fixattributes.sh` in `src`.
+run `make install` in `src`.
 
 type `gcc -o yab-compress yab-compress.c -lz` in `/yab-IDE/BuildFactory`.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,12 +42,14 @@ GCC = gcc
 GCC_OPT = $(DBG) $(OPT) -I. -I/boot/home/config/include/ -I/boot/home/config/include/ncurses/ -DHAVE_CONFIG -DUNIX $(HAIKUOPT)
 GPP = g++
 GPP_OPT = $(DBG) $(OPT) -I. -DHAVE_CONFIG -DUNIX $(HAIKUOPT)
+LD = ld
+LD_OPT = -shared
 
 ##
 ## Libraries
 ##
 ##LIBPATH = -L/boot/home/config/lib
-LIBPATHS = $(shell findpaths -a `getarch` B_FIND_PATH_LIB_DIRECTORY)
+LIBPATHS = $(shell findpaths -a `getarch` B_FIND_PATH_LIB_DIRECTORY) .
 LIBPATH=$(addprefix -L,$(LIBPATHS))
 ##LIBPATH = -L`finddir B_SYSTEM_LIB_DIRECTORY` ##/boot/system/lib    
 LIB = -lbe -lroot -ltranslation -ltracker -lmedia  
@@ -56,18 +58,24 @@ LIB = -lbe -lroot -ltranslation -ltracker -lmedia
 FLEXFLAGS = -i -I -L -s
 
 ## flags for bison (-t -v for debugging)
-BISONFLAGS = -d -l -t -v  
+BISONFLAGS = -d -l -t -v
+
+YAB_OBJECTS = YabInterface.o YabWindow.o YabView.o YabBitmapView.o YabText.o YabFilePanel.o YabFilePanelLooper.o YabList.o \
+	function.o io.o graphic.o symbol.o bison.o \
+	$(COLUMN) column/YabColumnType.o column/ColorTools.o \
+	YabStackView.o SplitPane.o URLView.o YabControlLook.o $(HAIKUTAB) Spinner.o $(TABLIB) CalendarControl.o
 
 ##
 ## Compile and link
 ##
-yab: YabMain.o YabInterface.o YabWindow.o YabView.o YabBitmapView.o YabFilePanel.o YabFilePanelLooper.o YabList.o \
-	YabText.o flex.o bison.o symbol.o function.o graphic.o io.o main.o $(COLUMN) column/YabColumnType.o column/ColorTools.o YabStackView.o SplitPane.o URLView.o YabControlLook.o \
-	$(HAIKUTAB) Spinner.o column/ColumnListView.o CalendarControl.o
-	$(GPP) $(GPP_OPT) -o yab YabMain.o YabInterface.o YabWindow.o YabView.o YabBitmapView.o YabText.o YabFilePanel.o \
-		YabFilePanelLooper.o YabList.o main.o function.o io.o graphic.o symbol.o bison.o flex.o  $(COLUMN) column/YabColumnType.o column/ColorTools.o \
-		YabStackView.o SplitPane.o URLView.o YabControlLook.o $(HAIKUTAB) Spinner.o $(TABLIB) CalendarControl.o \
-		$(LIBPATH) $(LIB)
+yab: libyab.so YabMain.o main.o bison.o flex.o RdefApply YAB.rdef
+	$(GPP) $(GPP_OPT) -o $@ YabMain.o main.o bison.o flex.o $(LIBPATH) libyab.so $(LIB)
+	$@ RdefApply YAB.rdef $@
+	addattr -t mime BEOS:TYPE application/x-vnd.be-elfexecutable $@
+
+libyab.so: $(YAB_OBJECTS)
+	$(LD) $(LD_OPT) -o $@ $+ $(LIBPATH) $(LIB)
+
 YabMain.o: YabMain.cpp 
 	$(GPP) $(GPP_OPT) -c YabMain.cpp -o YabMain.o
 YabInterface.o: YabInterface.cpp YabInterface.h YabMenu.h
@@ -126,4 +134,15 @@ YabControlLook.o: YabControlLook.h YabControlLook.cpp
 	$(GPP) $(GPP_OPT) -c YabControlLook.cpp -o YabControlLook.o
 
 clean:
-	rm -f core *.o column/*.o flex.* bison.* yab yabasic.output
+	rm -f core *.o column/*.o flex.* bison.* yab yabasic.output libyab.so
+
+install: yab libyab.so
+	mkdir -p /boot/system/non-packaged/bin
+	mkdir -p /boot/system/non-packaged/lib
+	mkdir -p /boot/system/non-packaged/develop/headers/yab/column
+	mkdir -p /boot/system/non-packaged/develop/lib
+	cp -f yab /boot/system/non-packaged/bin/
+	cp -f libyab.so /boot/system/non-packaged/lib/
+	cp -f libyab.so /boot/system/non-packaged/develop/lib
+	cp -f *.h /boot/system/non-packaged/develop/headers/yab/
+	cp -f column/*.h /boot/system/non-packaged/develop/headers/yab/column/

--- a/src/Makefile
+++ b/src/Makefile
@@ -70,7 +70,7 @@ YAB_OBJECTS = YabInterface.o YabWindow.o YabView.o YabBitmapView.o YabText.o Yab
 ##
 yab: libyab.so YabMain.o main.o bison.o flex.o RdefApply YAB.rdef
 	$(GPP) $(GPP_OPT) -o $@ YabMain.o main.o bison.o flex.o $(LIBPATH) libyab.so $(LIB)
-	$@ RdefApply YAB.rdef $@
+	LIBRARY_PATH=$$LIBRARY_PATH:. $@ RdefApply YAB.rdef $@
 	addattr -t mime BEOS:TYPE application/x-vnd.be-elfexecutable $@
 
 libyab.so: $(YAB_OBJECTS)

--- a/src/fixattributes.sh
+++ b/src/fixattributes.sh
@@ -1,3 +1,0 @@
-#!sh
-yab RdefApply YAB.rdef yab
-addattr -t mime BEOS:TYPE application/x-vnd.be-elfexecutable yab

--- a/yab-IDE/BuildFactory/AutoFooter.mak
+++ b/yab-IDE/BuildFactory/AutoFooter.mak
@@ -5,73 +5,19 @@
 SH=$(shell finddir B_SYSTEM_HEADERS_DIRECTORY)
 UH= $(shell finddir B_USER_HEADERS_DIRECTORY)
 GCC = gcc
-GCC_OPT = $(DBG) $(OPT) -I. $(addprefix -I,$(SH)) $(addprefix -I,$(UH)) -DHAVE_CONFIG -DUNIX $(HAIKUOPT)
+GCC_OPT = $(DBG) $(OPT) -I. $(addprefix -I,$(SH)) $(addprefix -I,$(UH)) -DHAVE_CONFIG -DUNIX $(HAIKUOPT) -I/boot/system/non-packaged/develop/headers/yab
 GPP = g++
-GPP_OPT = $(DBG) $(OPT) -I. -DHAVE_CONFIG -DUNIX $(HAIKUOPT)
+GPP_OPT = $(DBG) $(OPT) -I. -DHAVE_CONFIG -DUNIX $(HAIKUOPT) -I/boot/system/non-packaged/develop/headers/yab
 
+yab: YabMain.o main.o flex.o
+	$(GPP) $(GPP_OPT) -o $(TARGET) YabMain.o main.o flex.o $(LIBPATH) $(LIB)
 
-##
-## Compile and link
-##
-yab: YabMain.o YabInterface.o YabWindow.o YabView.o YabBitmapView.o YabFilePanel.o YabFilePanelLooper.o YabList.o \
-	YabText.o flex.o bison.o symbol.o function.o graphic.o io.o main.o $(COLUMN) column/YabColumnType.o column/ColorTools.o YabStackView.o SplitPane.o URLView.o YabControlLook.o \
-	$(HAIKUTAB) Spinner.o column/ColumnListView.o CalendarControl.o
-	$(GPP) $(GPP_OPT) -o $(TARGET) YabMain.o YabInterface.o YabWindow.o YabView.o YabBitmapView.o YabText.o YabFilePanel.o \
-		YabFilePanelLooper.o YabList.o main.o function.o io.o graphic.o symbol.o bison.o flex.o  $(COLUMN) column/YabColumnType.o column/ColorTools.o \
-		YabStackView.o SplitPane.o URLView.o YabControlLook.o $(HAIKUTAB) Spinner.o $(TABLIB) CalendarControl.o \
-		$(LIBPATH) $(LIB)
 YabMain.o: YabMain.cpp 
 	$(GPP) $(GPP_OPT) -c YabMain.cpp -o YabMain.o
-YabInterface.o: YabInterface.cpp YabInterface.h global.h YabMenu.h
-	$(GPP) $(GPP_OPT) -c YabInterface.cpp -o YabInterface.o
-YabWindow.o: YabWindow.cpp YabWindow.h global.h
-	$(GPP) $(GPP_OPT) -c YabWindow.cpp -o YabWindow.o
-YabView.o: YabView.cpp YabView.h
-	$(GPP) $(GPP_OPT) -c YabView.cpp -o YabView.o
-YabBitmapView.o: YabBitmapView.cpp YabBitmapView.h
-	$(GPP) $(GPP_OPT) -c YabBitmapView.cpp -o YabBitmapView.o
-YabFilePanel.o: YabFilePanel.cpp YabFilePanel.h
-	$(GPP) $(GPP_OPT) -c YabFilePanel.cpp -o YabFilePanel.o
-YabFilePanelLooper.o: YabFilePanelLooper.cpp YabFilePanelLooper.h
-	$(GPP) $(GPP_OPT) -c YabFilePanelLooper.cpp -o YabFilePanelLooper.o
-YabList.o: YabList.cpp YabList.h
-	$(GPP) $(GPP_OPT) -c YabList.cpp -o YabList.o
-YabText.o: YabText.cpp YabText.h
-	$(GPP) $(GPP_OPT) -c YabText.cpp -o YabText.o
-bison.o: bison.c yabasic.h config.h 
-	$(GCC) $(GCC_OPT) -c bison.c -o bison.o
-flex.o: flex.c bison.c yabasic.h config.h
+flex.o: flex.c
 	$(GCC) $(GCC_OPT) -c flex.c -o flex.o
-function.o: function.c yabasic.h config.h
-	$(GCC) $(GCC_OPT) -c function.c -o function.o
-io.o: io.c yabasic.h config.h
-	$(GCC) $(GCC_OPT) -c io.c -o io.o
-graphic.o: graphic.c yabasic.h config.h
-	$(GCC) $(GCC_OPT) -c graphic.c -o graphic.o
-symbol.o: symbol.c yabasic.h config.h
-	$(GCC) $(GCC_OPT) -c symbol.c -o symbol.o
-main.o: main.c yabasic.h config.h 
+main.o: main.c
 	$(GCC) $(GCC_OPT) -c main.c -o main.o
-YabStackView.o: YabStackView.cpp YabStackView.h
-	$(GPP) $(GPP_OPT) -c YabStackView.cpp -o YabStackView.o
-SplitPane.o: SplitPane.cpp SplitPane.h 
-	$(GPP) $(GPP_OPT) -c SplitPane.cpp -o SplitPane.o
-URLView.o: URLView.cpp URLView.h
-	$(GPP) $(GPP_OPT) -c URLView.cpp -o URLView.o
-Spinner.o: Spinner.cpp Spinner.h
-	$(GPP) $(GPP_OPT) -c Spinner.cpp -o Spinner.o
-column/ColumnListView.o: column/ColumnListView.cpp column/ColumnListView.h column/ObjectList.h 
-	$(GPP) $(GPP_OPT) -c column/ColumnListView.cpp -o column/ColumnListView.o
-column/ColorTools.o: column/ColorTools.cpp column/ColorTools.h 
-	$(GPP) $(GPP_OPT) -c column/ColorTools.cpp -o column/ColorTools.o
-column/YabColumnType.o: column/YabColumnType.cpp column/YabColumnType.h
-	$(GPP) $(GPP_OPT) -c column/YabColumnType.cpp -o column/YabColumnType.o
-$(HAIKUTAB): YabTabView.cpp YabTabView.h
-	$(GPP) $(GPP_OPT) -c YabTabView.cpp -o YabTabView.o
-CalendarControl.o: CalendarControl.cpp CalendarControl.h DateTextView.cpp MonthWindow.cpp MonthView.cpp MouseSenseStringView.cpp
-	$(GPP) $(GPP_OPT) -c CalendarControl.cpp -o CalendarControl.o
-YabControlLook.o: YabControlLook.h YabControlLook.cpp
-	$(GPP) $(GPP_OPT) -c YabControlLook.cpp -o YabControlLook.o
 
 clean:
 	rm -f core *.o column/*.o yabasic.output

--- a/yab-IDE/BuildFactory/AutoHeader.mak
+++ b/yab-IDE/BuildFactory/AutoHeader.mak
@@ -36,5 +36,5 @@ OPT = -O
 LIBPATHS = $(shell findpaths B_FIND_PATH_DEVELOP_LIB_DIRECTORY)
 LIBPATH=$(addprefix -L,$(LIBPATHS))
  
-LIB =  -lbe -lroot -ltranslation -ltracker -lmedia -lz
+LIB = -lyab -lbe -lroot -ltranslation -ltracker -lmedia -lz
 

--- a/yab-IDE/BuildFactory/flex-bison.yab
+++ b/yab-IDE/BuildFactory/flex-bison.yab
@@ -3,12 +3,13 @@
 doc This program modifies flex.c and main.c for the Buildfactory
 doc It accomplishes the seteps documented in HowToMakeABuildFactory.txt.
 doc The BuildFactory calls this program if flex.c is missing.
+doc Note that bison.h comes with the yab devel package, so we
+doc don't need to generate it ourselves anymore.
 doc
 doc by Jim Saxton, 2015, Artistic license
 
 system("flex -i -I -L -s -t yabasic.flex >flex.c")
 system("perl -i -n -e 'if (!/^\#include\s+<unistd.h>\s+$$/) {print if $$i;$$i++}' flex.c")
-system("bison  -d -l -t -v --output-file bison.c yabasic.bison ")
 system ("mv flex.c tmpflex.c")
 
 open #1, "tmpflex.c", "r"


### PR DESCRIPTION
- This also updates the BuildFactory Automakefile to
  make use of libyab.so.
- fixattributes.sh has been integrated into the
  Makefile, so is no longer required.
- yab binaries will now depend on libyab.so, including
  yab itself.
