### PR TITLE
Fix crashes and mismatched tabs in TabView.

### DIFF
--- a/src/YabInterface.cpp
+++ b/src/YabInterface.cpp
@@ -392,7 +392,7 @@ int YabInterface::CloseWindow(const char* view)
 						{
 							YabView *t = (YabView*)((YabTabView*)child)->TabAt(i)->View();
 							RemoveView(t);
-							viewList->DelView(t->Name());
+							viewList->DelView(t->NameForTabView());
 						}
 					}
 					if(is_kind_of(child, YabBitmapView))
@@ -409,7 +409,7 @@ int YabInterface::CloseWindow(const char* view)
 								{
 									YabView *t = (YabView*)((YabTabView*)subchild)->TabAt(i)->View();
 									RemoveView(t);
-									viewList->DelView(t->Name());
+									viewList->DelView(t->NameForTabView());
 								}
 							}
 							if(viewList->GetView(subchild->Name()))
@@ -3385,7 +3385,7 @@ void YabInterface::WindowClear(const char* window)
 						{
 							YabView *t = (YabView*)((YabTabView*)child)->TabAt(i)->View();
 							RemoveView(t);
-							viewList->DelView(t->Name());
+							viewList->DelView(t->NameForTabView());
 						}
 					}
 					if(is_kind_of(child, YabBitmapView))
@@ -3400,7 +3400,7 @@ void YabInterface::WindowClear(const char* window)
 								{
 									YabView *t = (YabView*)((YabTabView*)subchild)->TabAt(i)->View();
 									RemoveView(t);
-									viewList->DelView(t->Name());
+									viewList->DelView(t->NameForTabView());
 								}
 							}
 							if(viewList->GetView(subchild->Name()))
@@ -3465,7 +3465,7 @@ void YabInterface::RemoveView(BView *myView)
 			{
 				YabView *t = (YabView*)((YabTabView*)child)->TabAt(i)->View();
 				RemoveView(t);
-				viewList->DelView(t->Name());
+				viewList->DelView(t->NameForTabView());
 			}
 		}
 		if(is_kind_of(child, YabBitmapView))
@@ -3480,7 +3480,7 @@ void YabInterface::RemoveView(BView *myView)
 					{
 						YabView *t = (YabView*)((YabTabView*)subchild)->TabAt(i)->View();
 						RemoveView(t);
-						viewList->DelView(t->Name());
+						viewList->DelView(t->NameForTabView());
 					}
 				}
 				if(viewList->GetView(subchild->Name()))

--- a/src/YabView.cpp
+++ b/src/YabView.cpp
@@ -48,6 +48,11 @@ YabView::YabView(BRect frame, const char *name, uint32 resizingMode, uint32 flag
 	dropZone = false;
 	pressedKeys.SetTo("");
 	SetDrawingMode(B_OP_COPY);
+
+	// BTab uses view Name() as displayed label storage, so SetLabel changes it
+	// this interferes with yab method of referencing views by name
+	// to be removed
+	nameWAForTabView = name;
 }
 
 YabView::~YabView()

--- a/src/YabView.h
+++ b/src/YabView.h
@@ -27,6 +27,7 @@ class YabView : public BView
 		virtual void MouseDown(BPoint point);
 		virtual void KeyUp(const char *bytes, int32 numBytes);
 		virtual void KeyDown(const char *bytes, int32 numBytes);
+		const char* NameForTabView() { return nameWAForTabView; }
 		BList *drawList;
 		int mouseMovedInfo;
 		int mouseStateInfo;
@@ -39,6 +40,8 @@ class YabView : public BView
 		BString pressedKeys;
 	private:
 		int prevMouseStateInfo;
+		// TODO: revisit at a later time, more info in constructor
+		BString nameWAForTabView;
 };
 
 #endif


### PR DESCRIPTION
* Default BTab uses view's name property as tab label, so
  SetLabel changes that value. However, view names are important
  for yab and this would cause inconsistencies in view lists yab
  stores for referencing them by name. Views attached to tabs would
  not be removed because there is no name "Tab1" in the index
  (there is "Test1", which is the view's original name).
  Later, when asking for view with the same name created later yab
  could get wrong view (if lucky) or crash (if unlucky).
  This commit fixes that by storing original name in YabView
  property, and using that for removing views from the hierarchy.
* Fixes #5.

Adding to that, I will be raising this issue on Haiku's development list, because that behavior is potential source of problems. Additionally, it's not possible to customize tab label rendering without introducing dependency on BControlLook which is problematic.